### PR TITLE
fix: automate Windows build setup with setup.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Terraria-inspired 2D game built with C++ and SFML 3.
 
 | Platform | Requirements |
 |----------|-------------|
-| **Windows** | [Visual Studio 2017+](https://visualstudio.microsoft.com/) (with *Desktop development with C++*) or [MinGW-w64](https://www.mingw-w64.org/), [CMake 3.11+](https://cmake.org/download/), [Git 2.0+](https://git-scm.com/) |
+| **Windows** | [Git 2.0+](https://git-scm.com/) — everything else is installed automatically by `setup.ps1` |
 | **Linux (Arch)** | `sudo pacman -S cmake base-devel git` |
 | **Linux (Ubuntu/Debian)** | `sudo apt install cmake build-essential git libx11-dev libxrandr-dev libxcursor-dev libxi-dev libudev-dev libgl-dev libfreetype-dev libopenal-dev libflac-dev libvorbis-dev` |
 | **macOS** | `xcode-select --install && brew install cmake git` |
@@ -27,8 +27,8 @@ cd MyCloneTerarria
 # Linux / macOS
 make deps
 
-# Windows (PowerShell)
-pwsh scripts/build-deps.ps1
+# Windows (PowerShell) — installs CMake, VS Build Tools, builds SFML and the game
+pwsh scripts/setup.ps1
 ```
 
 **3. Build and run the game**
@@ -37,13 +37,13 @@ pwsh scripts/build-deps.ps1
 # Linux / macOS
 make run
 
-# Windows (PowerShell)
-cmake -B build -S .
+# Windows (PowerShell) — after setup.ps1 has been run once
+cmake -B build -S . -G "Visual Studio 17 2022" -A x64
 cmake --build build --config Release
 build\Release\MyCloneTerraria.exe
 ```
 
-> After the first `make deps` / `build-deps.ps1`, only your game sources are recompiled on each build — SFML is reused from `.deps/sfml-install/`.
+> After the first `make deps` / `setup.ps1`, only your game sources are recompiled on each build — SFML is reused from `.deps/sfml-install/`.
 
 ## Development Workflow
 
@@ -77,7 +77,7 @@ build\MyCloneTerraria.exe
 MyCloneTerraria/
 ├── src/            # Source and header files (.cpp / .h)
 ├── assets/         # Textures and sounds
-├── scripts/        # build-deps.sh / build-deps.ps1 / dev.sh
+├── scripts/        # setup.ps1 / build-deps.sh / build-deps.ps1 / dev.sh
 └── CMakeLists.txt  # Build configuration
 ```
 

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -19,10 +19,14 @@ if (-not (Test-Path $SfmlSrc)) {
     git clone --depth=1 --branch $SfmlTag https://github.com/SFML/SFML.git $SfmlSrc
 }
 
+Write-Host "Cleaning build directory..."
+Remove-Item -Recurse -Force $SfmlBuild -ErrorAction SilentlyContinue
+
 Write-Host "Building SFML (this happens once)..."
-cmake -B $SfmlBuild -S $SfmlSrc `
+cmake -B "$SfmlBuild" -S "$SfmlSrc" `
+    -G "Visual Studio 17 2022" -A x64 `
     -DCMAKE_BUILD_TYPE=Release `
-    -DCMAKE_INSTALL_PREFIX=$SfmlInstall `
+    "-DCMAKE_INSTALL_PREFIX=$SfmlInstall" `
     -DSFML_BUILD_SHARED_LIBS=OFF `
     -DSFML_BUILD_EXAMPLES=OFF `
     -DSFML_BUILD_TEST_SUITE=OFF

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -1,0 +1,52 @@
+# One-shot setup: installs prerequisites, builds SFML, and builds the game
+$ErrorActionPreference = "Stop"
+
+function Has-Command($cmd) {
+    return [bool](Get-Command $cmd -ErrorAction SilentlyContinue)
+}
+
+function Refresh-Path {
+    $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH", "Machine") + ";" +
+                [System.Environment]::GetEnvironmentVariable("PATH", "User")
+}
+
+# Install CMake if missing
+if (-not (Has-Command "cmake")) {
+    Write-Host "Installing CMake via winget..."
+    winget install --id Kitware.CMake -e --accept-source-agreements --accept-package-agreements
+    Refresh-Path
+}
+
+# Install Git if missing
+if (-not (Has-Command "git")) {
+    Write-Host "Installing Git via winget..."
+    winget install --id Git.Git -e --accept-source-agreements --accept-package-agreements
+    Refresh-Path
+}
+
+# Install Visual Studio Build Tools (C++ workload) if cl.exe not found
+if (-not (Has-Command "cl")) {
+    Write-Host "Installing Visual Studio 2022 Build Tools (C++ workload)..."
+    Write-Host "This is a large download (~2 GB) and may take several minutes."
+    winget install --id Microsoft.VisualStudio.2022.BuildTools -e --accept-source-agreements --accept-package-agreements `
+        --override "--quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+    Refresh-Path
+}
+
+Write-Host "cmake: $(cmake --version | Select-Object -First 1)"
+Write-Host "git:   $(git --version)"
+
+$ProjectDir = (Get-Item "$PSScriptRoot\..").FullName
+
+# Build SFML in a fresh shell so newly installed tools are on PATH
+pwsh -NoProfile -ExecutionPolicy Bypass -File "$PSScriptRoot\build-deps.ps1"
+
+# Build the game
+Write-Host ""
+Write-Host "Building the game..."
+cmake -B "$ProjectDir\build" -S "$ProjectDir" -G "Visual Studio 17 2022" -A x64
+cmake --build "$ProjectDir\build" --config Release --parallel
+
+Write-Host ""
+Write-Host "Done! Run the game with:"
+Write-Host "  $ProjectDir\build\Release\MyCloneTerraria.exe"


### PR DESCRIPTION
Add scripts/setup.ps1 to install CMake, Git, and VS 2022 Build Tools via winget, then build SFML and the game in one command. Fix build-deps.ps1 to use the VS 2022 generator explicitly and quote paths to prevent variable expansion issues.